### PR TITLE
Buildfix

### DIFF
--- a/src/os/libretro/libretro.cxx
+++ b/src/os/libretro/libretro.cxx
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf


### PR DESCRIPTION
```
../../os/libretro/libretro.cxx:58:18: error: 'strdup' was not declared in this scope; did you mean 'strcmp'?
   58 |   char *string = strdup(source);
      |                  ^~~~~~
      |                  strcmp
```