### PR TITLE
ci: add Linux arm64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-arm64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -92,6 +96,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-arm64:
+  extends:
+    - .libretro-linux-arm64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The buildbot currently builds linux-x64/i686, osx, android, ios, Switch, tvOS and webOS but no desktop Linux **aarch64**. This adds the `/linux-arm64.yml` template include and a `libretro-build-linux-arm64` job (mirroring `libretro-build-linux-x64`) so the buildbot produces a Linux ARM64 core.

Same change as stella-emu/stella#1154, applied here to the stella2023 core recipe.