### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -92,6 +96,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
Second attempt at #8, which had to be reverted in #9 because it broke the CI pipelines.

**What was wrong before:** the previous PR used `/linux-arm64.yml` and `.libretro-linux-arm64-make-default`. Neither exists in `libretro-infrastructure/ci-templates` — the desktop Linux ARM template is named `aarch64`, and only the Apple targets use `arm64` (`osx-arm64.yml`, `ios-arm64.yml`, `tvos-arm64.yml`), which is what made the wrong spelling look plausible. Since GitLab resolves `include:` while *creating* the pipeline, a missing template file is not a failing job — no pipeline is generated at all, so every platform breaks at once. Hence the immediate revert.

**This PR** uses the names that actually exist:

```yaml
  - project: 'libretro-infrastructure/ci-templates'
    file: '/linux-aarch64.yml'

libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

which is the same shape dozens of cores already use (`fuse-libretro`, `mame2003-plus`, `beetle-psx`, `parallel-n64`, …).

**Checks done before opening this:**
- `linux-aarch64.yml` exists in `ci-templates` and defines `.libretro-linux-aarch64-make-default` (image `libretro-build-aarch64-ubuntu:latest`, tag `aarch64`, `CC: gcc` / `CXX: g++`).
- No image or compiler override is needed: that image installs gcc-12/g++-12 and points `gcc`/`g++` at them via `update-alternatives`, so the C++ standard the libretro Makefile asks for is covered. (There is deliberately no `:backports` tag for the aarch64 image, unlike amd64.)
- The core builds clean on real aarch64 hardware from this branch: `cd src/os/libretro && make platform=unix` produces `stella2023_libretro.so` (Linux aarch64, GCC).

Only the desktop Linux ARM64 job is added; nothing else in the file changes.